### PR TITLE
Warn instead of error  on consecutive plus groups

### DIFF
--- a/apply_patches_as_suggestion.py
+++ b/apply_patches_as_suggestion.py
@@ -202,6 +202,7 @@ def parse_suggestions_from_hunk(hunk):
                 "suggestion is:", 
                 "".join(line.value for line in added_group),
             )
+            continue
 
         # Join all lines and remove trailing newline
         suggestion = "".join(line.value for line in suggestion_lines)[:-1]

--- a/apply_patches_as_suggestion.py
+++ b/apply_patches_as_suggestion.py
@@ -196,8 +196,11 @@ def parse_suggestions_from_hunk(hunk):
             # suggestion so it doesn't get deleted
             suggestion_lines = [predecessor_group[-1], *added_group]
         else:
-            raise Exception(
-                f"Invariant violated. Consecutive '+' groups at indices {added_group_index - 1}, {added_group_index}:\n{''.join(predecessor_group)}\n{''.join(added_group)}"
+            print(
+                "Warning - discarding suggestion of added lines. It follows "
+                "after another suggestion of added lines. The discarded "
+                "suggestion is:", 
+                "".join(line.value for line in added_group),
             )
 
         # Join all lines and remove trailing newline


### PR DESCRIPTION
Hopefully this will solve/mitigate this bug [CE-130](https://cloudtostreet.atlassian.net/browse/CE-130) that sometimes causes black-suggest to fail