### PR TITLE
add git permission hotfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Let git know that this directory is safe. 
+#  Necessary due to this debain patch that's affecting github CIs
 # https://github.com/actions/runner-images/issues/6775
 RUN git config --system --add safe.directory /github/workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 # https://github.com/actions/runner-images/issues/6775
-RUN git config --system --add safe.directory ./
+RUN git config --system --add safe.directory /github/workspace
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
+# https://github.com/actions/runner-images/issues/6775
+RUN git config --system --add safe.directory *
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 # https://github.com/actions/runner-images/issues/6775
-RUN git config --system --add safe.directory *
+RUN git config --system --add safe.directory ./
 
 COPY . .
 


### PR DESCRIPTION
### what I did
Set the github workspace to be a git safe directory.

### checks
* [x] with this patch, failing black-suggest CIs now pass
  * [CI run before this patch](https://github.com/cloudtostreet/pf_ml/actions/runs/4126877949)
  * [CI run after this patch ](https://github.com/cloudtostreet/pf_ml/actions/runs/4127368501)

### notes
* detailed issue and discussion in the github actions community: https://github.com/actions/runner-images/issues/6775